### PR TITLE
Add OUTPUT-FILTER option

### DIFF
--- a/reformatter-tests.el
+++ b/reformatter-tests.el
@@ -71,7 +71,8 @@
 (reformatter-define reformatter-tests-output-filter-reverse
   :program "cat"
   :output-filter (lambda ()
-                   (reverse-region (point-min) (point-max)))
+                   (reverse-region (point-min) (point-max))
+                   t)
   :args nil)
 
 (ert-deftest reformatter-tests-output-filter ()
@@ -79,6 +80,18 @@
     (insert "one\ntwo\n")
     (reformatter-tests-output-filter-reverse)
     (should (equal "two\none\n" (buffer-string)))))
+
+(reformatter-define reformatter-tests-output-filter-no-op
+  :program "wc"
+  :output-filter (lambda ()
+                   nil)
+  :args nil)
+
+(ert-deftest reformatter-tests-output-filter-no-op ()
+  (with-temp-buffer
+    (insert "one\ntwo\n")
+    (reformatter-tests-output-filter-no-op)
+    (should (equal "one\ntwo\n" (buffer-string)))))
 
 (provide 'reformatter-tests)
 ;;; reformatter-tests.el ends here

--- a/reformatter-tests.el
+++ b/reformatter-tests.el
@@ -68,7 +68,17 @@
     (reformatter-tests-shfmt-in-place)
     (should (equal "[ foo ] && echo yes\n" (buffer-string)))))
 
+(reformatter-define reformatter-tests-output-filter-reverse
+  :program "cat"
+  :output-filter (lambda ()
+                   (reverse-region (point-min) (point-max)))
+  :args nil)
 
+(ert-deftest reformatter-tests-output-filter ()
+  (with-temp-buffer
+    (insert "one\ntwo\n")
+    (reformatter-tests-output-filter-reverse)
+    (should (equal "two\none\n" (buffer-string)))))
 
 (provide 'reformatter-tests)
 ;;; reformatter-tests.el ends here


### PR DESCRIPTION
Closes #25, #26: this is similar but avoids leaving dangling temp files.

An `eslint --fix` formatter written with this facility looks like this:
```el
  (reformatter-define eslint-fix
    :program "eslint"
    :args `("--fix-dry-run"
            "--format"
            "json"
            "--stdin"
            "--stdin-filename"
            ,buffer-file-name
            "--ext"
            ".json,.js,.jsx,.mjs,.mjsx,.cjs,.cjsx,.ts,.tsx")
    :output-filter (lambda ()
                     (let-alist (elt (json-read-array) 0)
                       (when .output
                         (delete-region (point-min) (point-max))
                         (insert .output)
                         t))))
```
However, this fails when there are no fixes applicable to the current buffer, because no replacement `output` is included. We would need a structured way for the `output-filter` function to indicate that it has determined there are no changes to be made. `eslint --fix` returns a zero exit code in either case.