### PR TITLE
Use Emacs > 21 define-minor-mode call convention

### DIFF
--- a/reformatter.el
+++ b/reformatter.el
@@ -250,7 +250,7 @@ might use:
 
      ((some-major-mode
         (mode . %s-on-save)))
- " buffer-fn-name name) nil
+ " buffer-fn-name name)
                    :global nil
                    :lighter ,lighter-name
                    :keymap ,keymap


### PR DESCRIPTION
So the byte compiler can stop warning  ```Warning: Use keywords rather than deprecated positional arguments to `define-minor-mode'```