### PR TITLE
Handle slashes in names of created functions when creating temporary files

### DIFF
--- a/reformatter-tests.el
+++ b/reformatter-tests.el
@@ -55,6 +55,19 @@
     (reformatter-tests-shfmt-tempfile-in-stdout)
     (should (equal "[ foo ] && echo yes\n" (buffer-string)))))
 
+;; Same as `reformatter-tests-shfmt-tempfile-in-stdout', but with a
+;; slash in the symbol name.
+(reformatter-define reformatter-tests-tempfile/with-slash-in-symbol-name
+  :program "shfmt"
+  :stdin nil
+  :args (list input-file))
+
+(ert-deftest reformatter-tests-tempfile-with-slash-in-symbol-name ()
+  (with-temp-buffer
+    (insert "[  foo  ] && echo yes\n")
+    (reformatter-tests-tempfile/with-slash-in-symbol-name)
+    (should (equal "[ foo ] && echo yes\n" (buffer-string)))))
+
 ;; Modify a file in place
 (reformatter-define reformatter-tests-shfmt-in-place
   :program "shfmt"
@@ -67,7 +80,6 @@
     (insert "[  foo  ] && echo yes\n")
     (reformatter-tests-shfmt-in-place)
     (should (equal "[ foo ] && echo yes\n" (buffer-string)))))
-
 
 
 (provide 'reformatter-tests)

--- a/reformatter-tests.el
+++ b/reformatter-tests.el
@@ -65,7 +65,7 @@
 (ert-deftest reformatter-tests-tempfile-with-slash-in-symbol-name ()
   (with-temp-buffer
     (insert "[  foo  ] && echo yes\n")
-    (reformatter-tests-tempfile/with-slash-in-symbol-name)
+    (reformatter-tests-tempfile/with-slash-in-symbol-name-buffer)
     (should (equal "[ foo ] && echo yes\n" (buffer-string)))))
 
 ;; Modify a file in place

--- a/reformatter.el
+++ b/reformatter.el
@@ -111,10 +111,10 @@ the `reformatter-define' macro."
                  (retcode
                   (condition-case e
                       (apply 'call-process program
-                                  (when stdin input-file)
-                                  (list (list :file stdout-file) stderr-file)
-                                  nil
-                                  args)
+                             (when stdin input-file)
+                             (list (list :file stdout-file) stderr-file)
+                             nil
+                             args)
                     (error e))))
             (with-current-buffer error-buffer
               (let ((inhibit-read-only t))
@@ -277,7 +277,7 @@ DISPLAY-ERRORS, shows a buffer if the formatting fails."
          (interactive "rp")
          (let ((input-file ,(if input-file
                                 input-file
-                              (reformatter--make-temp-file name))))
+                              `(reformatter--make-temp-file ',name))))
            ;; Evaluate args with input-file bound
            (unwind-protect
                (progn


### PR DESCRIPTION
Previously, if the symbol passed to `reformatter-define` contained a slash, then the actual formatting would fail due to `make-temp-file` implicitly trying to create a directory inside `/tmp`. I've worked around this by replacing the `/` with an underscore for temp file creation, and written a test to see if it works correctly (and checked that it failed before).

I haven't really written much Elisp though, so there might be a smarter way to do this. Happy about any feedback :)