### PR TITLE
Integrate with `read-extended-command-predicate`

### DIFF
--- a/reformatter-tests.el
+++ b/reformatter-tests.el
@@ -81,6 +81,37 @@
     (reformatter-tests-shfmt-in-place-buffer)
     (should (equal "[ foo ] && echo yes\n" (buffer-string)))))
 
+;; Formatting commands tagged for specific modes: `command-modes' checks which
+;; modes they're defined to be interactively usable in, but it's only available
+;; in Emacs 28 and newer.
+(when (fboundp 'command-modes)
+  (reformatter-define reformatter-tests-shfmt-no-interactive-modes
+    :program "shfmt")
+
+  (ert-deftest reformatter-tests-no-interactive-modes ()
+    (should (not (command-modes 'reformatter-tests-shfmt-no-interactive-modes-buffer)))
+    (should (not (command-modes 'reformatter-tests-shfmt-no-interactive-modes-region))))
+
+  (reformatter-define reformatter-tests-shfmt-single-interactive-mode
+    :program "shfmt"
+    :interactive-modes (sh-mode))
+
+  (ert-deftest reformatter-tests-single-interactive-mode ()
+    (should (equal (command-modes 'reformatter-tests-shfmt-single-interactive-mode-buffer)
+                   '(sh-mode)))
+    (should (equal (command-modes 'reformatter-tests-shfmt-single-interactive-mode-region)
+                   '(sh-mode))))
+
+  (reformatter-define reformatter-tests-shfmt-multiple-interactive-modes
+    :program "shfmt"
+    :interactive-modes (sh-mode haskell-mode))
+
+  (ert-deftest reformatter-tests-multiple-interactive-modes ()
+    (should (equal (command-modes 'reformatter-tests-shfmt-multiple-interactive-modes-buffer)
+                   '(sh-mode haskell-mode)))
+    (should (equal (command-modes 'reformatter-tests-shfmt-multiple-interactive-modes-region)
+                   '(sh-mode haskell-mode)))))
+
 
 (provide 'reformatter-tests)
 ;;; reformatter-tests.el ends here

--- a/reformatter.el
+++ b/reformatter.el
@@ -143,7 +143,7 @@ WORKING-DIRECTORY see the documentation of the `reformatter-define' macro."
       (delete-file stdout-file))))
 
 ;;;###autoload
-(cl-defmacro reformatter-define (name &key program args (mode t) (stdin t) (stdout t) input-file lighter keymap group (exit-code-success-p 'zerop) working-directory)
+(cl-defmacro reformatter-define (name &key program args (mode t) (stdin t) (stdout t) input-file lighter keymap group (exit-code-success-p 'zerop) working-directory interactive-modes)
   "Define a reformatter command with NAME.
 
 When called, the reformatter will use PROGRAM and any ARGS to
@@ -241,7 +241,16 @@ WORKING-DIRECTORY
 
   Directory where your reformatter program is started. If provided, this
   should be a form that evaluates to a string at runtime. Default is the
-  value of `default-directory' in the buffer."
+  value of `default-directory' in the buffer.
+
+INTERACTIVE-MODES
+
+  If provided, this is a list of mode names (as unquoted
+  symbols).  The created commands for formatting regions and
+  buffers are then tagged for interactive use in these modes,
+  making them compatible with some built-in predicate functions
+  for `read-extended-command-predicate', like
+  `command-completion-default-include-p'."
   (declare (indent defun))
   (cl-assert (symbolp name))
   (cl-assert (functionp exit-code-success-p))
@@ -282,7 +291,7 @@ might use:
          "Reformats the region from BEG to END.
 When called interactively, or with prefix argument
 DISPLAY-ERRORS, shows a buffer if the formatting fails."
-         (interactive "rp")
+         (interactive "rp" ,@interactive-modes)
          (let ((input-file ,(if input-file
                                 input-file
                               `(reformatter--make-temp-file ',name))))
@@ -300,7 +309,7 @@ DISPLAY-ERRORS, shows a buffer if the formatting fails."
          "Reformats the current buffer.
 When called interactively, or with prefix argument
 DISPLAY-ERRORS, shows a buffer if the formatting fails."
-         (interactive "p")
+         (interactive "p" ,@interactive-modes)
          (message "Formatting buffer")
          (,region-fn-name (point-min) (point-max) display-errors))
 


### PR DESCRIPTION
Motivation: Since Emacs 28.1 (I think) we have the option to add modes to `interactive`, say `(interactive nil haskell-mode emacs-lisp-mode)`. The Emacs variable `read-extended-command-predicate` (when set to some predicate, for instance `command-completion-default-include-p`) then leads to those commands only being shown in `M-x` completion when the current buffer is in one of those modes.

I've added the `:interactive-modes` keyword, taking a list of those modes that are then passed to `interactive`, and tested it accordingly.

Some points/questions:
- I'm not sure about the keyword naming. `:modes` would (I think) suggest something regarding the created minor mode, or similar to the `:hooks` behaviour in `use-package`, so I opted for a longer name giving the `interactive` context.
- `:interactive-modes` expects an unquoted list of modes. It was easiest to implement it this way, as we can just splice it into `interactive`, which takes them as `&rest`. Is this fine?
- Would it be better to special-case the single-mode version, allowing to omit the parentheses?
- Should we make it clear that this is only for recent-enough Emacsen?

I personally find it *very* handy and nice to have my custom commands automatically narrowed down like this; just the ones defined with `reformatter-define` "stick out" a little bit, hence this PR. I'd be glad if you considered this in some way or other :)